### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,19 +21,21 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - if: matrix.os == 'windows-latest'
       name: setup-msbuild
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.12
+      uses: jwlawson/actions-setup-cmake@v2
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
     - name: Install click
       run: pip install click
@@ -50,7 +52,7 @@ jobs:
       run: unzip builds/${{ matrix.build }} -d artifacts
 
     - name: Upload ${{ matrix.os }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: discord-rpc-${{ matrix.os }}
         path: artifacts


### PR DESCRIPTION
Fix warnings found in https://github.com/harmonytf/discord-rpc/actions/runs/9522981367:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, microsoft/setup-msbuild@v1.1, jwlawson/actions-setup-cmake@v1.12, actions/setup-python@v2, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "discord-rpc-macos-latest", "discord-rpc-ubuntu-latest", "discord-rpc-windows-latest".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/