### PR TITLE
Use rapidjson sse2 only if supported

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,8 +25,6 @@ if (${BUILD_SHARED_LIBS})
     endif(WIN32)
 endif(${BUILD_SHARED_LIBS})
 
-add_definitions(-DRAPIDJSON_SSE2)
-
 if(WIN32)
     add_definitions(-DDISCORD_WINDOWS)
     set(BASE_RPC_SRC ${BASE_RPC_SRC} connection_win.cpp discord_register_win.cpp)

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -12,6 +12,11 @@
 #pragma warning(disable : 6313) // Incorrect operator
 #endif                          // __MINGW32__
 
+#if defined(_M_X64) || defined(_M_AMD64) || defined(__x86_64__) || \
+    defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP == 2)
+#define RAPIDJSON_SSE2
+#endif
+
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"


### PR DESCRIPTION
With these changes, discord-rpc can be now be build for arm/arm64 architectures