### PR TITLE
Do not force mmacosx-version-min flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,7 @@ if(UNIX)
     target_link_libraries(discord-rpc PUBLIC pthread)
 
     if (APPLE)
-        target_link_libraries(discord-rpc PRIVATE "-framework AppKit, -mmacosx-version-min=10.10")
+        target_link_libraries(discord-rpc PRIVATE "-framework AppKit")
     endif (APPLE)
 
     target_compile_options(discord-rpc PRIVATE


### PR DESCRIPTION
This should be handled by CMake with CMAKE_OSX_DEPLOYMENT_TARGET