### PR TITLE
Use target_include_directories to publicly expose include dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
 option(ENABLE_IO_THREAD "Start up a separate I/O thread, otherwise I'd need to call an update function" ON)
 option(USE_STATIC_CRT "Use /MT[d] for dynamic library" OFF)
 option(WARNINGS_AS_ERRORS "When enabled, compiles with `-Werror` (on *nix platforms)." OFF)
@@ -113,6 +111,8 @@ if(UNIX)
 endif(UNIX)
 
 target_include_directories(discord-rpc PRIVATE ${RAPIDJSON}/include)
+
+target_include_directories(discord-rpc PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 
 if (NOT ${ENABLE_IO_THREAD})
     target_compile_definitions(discord-rpc PUBLIC -DDISCORD_DISABLE_IO_THREAD)


### PR DESCRIPTION
To use discord-rpc in a project before this change:
```
add_subdirectory(discord-rpc)
target_include_directories(${PROJECT_NAME} PRIVATE discord-rpc/include)
target_link_libraries(${PROJECT_NAME} PRIVATE discord-rpc)
```

To use discord-rpc in a project after this change:
```
add_subdirectory(discord-rpc)
target_link_libraries(${PROJECT_NAME} PRIVATE discord-rpc)
```